### PR TITLE
Use tar version.txt instead of yaml defined version.txt

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,17 +1,15 @@
 #!/bin/bash -e
 
-#SRC="/app/extra/wt.tar.gz"
-#XDG_DATA_HOME="/app/extra/tmp/"
+SRC="/app/extra/wt.tar.gz"
+XDG_DATA_HOME="/app/extra/tmp/"
 
 # Setup
-#mkdir -p $XDG_DATA_HOME
+mkdir -p $XDG_DATA_HOME
 
 # Extract
-#tar -xv --gzip -f $SRC -C $XDG_DATA_HOME
-
-# Export icon
-#mkdir -p "/app/extra/export/share/icons/hicolor/128x128/apps/"
-#mv -v "$XDG_DATA_HOME/WarThunder/launcher.ico" "/app/extra/export/share/icons/hicolor/128x128/apps/net.gaijin.WarThunder.png"
+tar -xv --gzip -f $SRC -C $XDG_DATA_HOME "WarThunder/launcherr.dat"
+ls $XDG_DATA_HOME
+unzip "$XDG_DATA_HOME/WarThunder/launcherr.dat" -d "/app/extra/" version.txt
 
 # Clean up
-#rm -rf $XDG_DATA_HOME
+rm -rf $XDG_DATA_HOME

--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -8,7 +8,6 @@ mkdir -p $XDG_DATA_HOME
 
 # Extract
 tar -xv --gzip -f $SRC -C $XDG_DATA_HOME "WarThunder/launcherr.dat"
-ls $XDG_DATA_HOME
 unzip "$XDG_DATA_HOME/WarThunder/launcherr.dat" -d "/app/extra/" version.txt
 
 # Clean up

--- a/net.gaijin.WarThunder.yaml
+++ b/net.gaijin.WarThunder.yaml
@@ -18,11 +18,10 @@ modules:
     buildsystem: simple
     build-commands:
       - install -D -t "${FLATPAK_DEST}/bin/" ./run.sh
-      #- install -D ./apply_extra.sh "${FLATPAK_DEST}/bin/apply_extra"
+      - install -D ./apply_extra.sh "${FLATPAK_DEST}/bin/apply_extra"
       - install -D -t "${FLATPAK_DEST}/share/applications/" ./net.gaijin.WarThunder.desktop
       - install -D ./net.gaijin.WarThunder-128.png "/app/share/icons/hicolor/128x128/apps/net.gaijin.WarThunder.png"
       - install -D -t "${FLATPAK_DEST}/share/metainfo/" ./net.gaijin.WarThunder.metainfo.xml
-      - echo "0.9.4.74" >> /app/bin/version
     sources:
       - type: extra-data
         filename: wt.tar.gz
@@ -38,8 +37,8 @@ modules:
         path: run.sh
       - type: file
         path: net.gaijin.WarThunder.desktop
-      #- type: file
-      #  path: apply_extra.sh
+      - type: file
+        path: apply_extra.sh
       - type: file
         path: net.gaijin.WarThunder.metainfo.xml
       - type: file

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,14 @@
 #!/bin/bash -e
 
+# Extra data tar
 SRC="/app/extra/wt.tar.gz"
+
+# Allows for custom install location
 DIR=${CUSTOM_DIR:-$XDG_DATA_HOME}
-FLAT_VERSION="/app/bin/version"
-DATA_VERSION="${DIR}/WarThunder/version"
+
+# Version files to compare
+FLAT_VERSION="/app/extra/version.txt" # Extracted with apply_extra.sh
+DATA_VERSION="${DIR}/WarThunder/version.txt"
 
 # Extract
 if [[ ! -f "$DATA_VERSION" ]] || [[ `cmp --silent "$FLAT_VERSION" "$DATA_VERSION"; echo $?` -ne 0 ]] ; then


### PR DESCRIPTION
This solves an issue in which FEDC is unable to update the version.txt declaration in YAML.
To solve this, this commit reapplies apply_extra, which task is to now extract the version.txt from deep in the tar.
This will fix the files being extracted over and over again, slowing launch times.